### PR TITLE
ensure meal is only saved once

### DIFF
--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -8,7 +8,8 @@ extension AddCarbs {
         @StateObject var state = StateModel()
         @State var dish: String = ""
         @State var isPromtPresented = false
-        @State var saved = false
+        @State var noteSaved = false
+        @State var mealSaved = false
         @State private var showAlert = false
         @FocusState private var isFocused: Bool
 
@@ -117,9 +118,12 @@ extension AddCarbs {
                 }
 
                 Section {
-                    Button { state.add() }
+                    Button {
+                        mealSaved = true
+                        state.add()
+                    }
                     label: { Text("Save and continue").font(.title3) }
-                        .disabled(state.carbs <= 0 && state.fat <= 0 && state.protein <= 0)
+                        .disabled(mealSaved || state.carbs <= 0 && state.fat <= 0 && state.protein <= 0)
                         .frame(maxWidth: .infinity, alignment: .center)
                 } footer: { Text(state.waitersNotepad().description) }
 
@@ -138,8 +142,8 @@ extension AddCarbs {
                 Section {
                     TextField("Name Of Dish", text: $dish)
                     Button {
-                        saved = true
-                        if dish != "", saved {
+                        noteSaved = true
+                        if dish != "", noteSaved {
                             let preset = Presets(context: moc)
                             preset.dish = dish
                             preset.fat = state.fat as NSDecimalNumber
@@ -147,14 +151,14 @@ extension AddCarbs {
                             preset.carbs = state.carbs as NSDecimalNumber
                             try? moc.save()
                             state.addNewPresetToWaitersNotepad(dish)
-                            saved = false
+                            noteSaved = false
                             isPromtPresented = false
                         }
                     }
                     label: { Text("Save") }
                     Button {
                         dish = ""
-                        saved = false
+                        noteSaved = false
                         isPromtPresented = false }
                     label: { Text("Cancel") }
                 } header: { Text("Enter Meal Preset Name") }


### PR DESCRIPTION
Disables `Save and continue` button once pressed by utilizing new `mealSaved` flag. Renames `saved` to `noteSaved`.